### PR TITLE
fix: use react 18 for expo compatibility

### DIFF
--- a/map_map-main/package.json
+++ b/map_map-main/package.json
@@ -33,9 +33,9 @@
     "leaflet": "^1.9.4",
     "react-leaflet": "^4.2.1",
     "lucide-react-native": "^0.475.0",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
-    "react-native": "0.79.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.76.3",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-maps": "^1.26.1",
     "react-native-reanimated": "~3.17.4",
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
-    "@types/react": "~19.0.10",
+    "@types/react": "~18.2.74",
     "typescript": "~5.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- align the React/React DOM versions with expo sdk 53 requirements
- update React Native and @types/react to compatible releases to satisfy react-leaflet peer deps

## Testing
- npm install *(fails: 403 Forbidden fetching lucide-react-native)*

------
https://chatgpt.com/codex/tasks/task_e_68da64f84c44832591ddda5939a151c3